### PR TITLE
Use Component mapper provided as a prop

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -5,6 +5,9 @@ import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import FormBuilder from '../src/index';
 
+import { componentMapper as pf4ComponentMapper } from '@data-driven-forms/pf4-component-mapper';
+import { componentMapper as muiComponentMapper } from '@data-driven-forms/mui-component-mapper';
+
 import {
   pickerMapper as muiPickerMapper,
   propertiesMapper as muiPropertiesMapper,
@@ -258,14 +261,16 @@ const pf4State = {
   pickerMapper: pf4PickerMapper,
   propertiesMapper: pf4PropertiesMapper,
   builderMapper: pf4PBuilderMapper,
-  BuilderTemplate: pf4BuilderTemplate
+  BuilderTemplate: pf4BuilderTemplate,
+  componentMapper: pf4ComponentMapper
 };
 
 const muiState = {
   pickerMapper: muiPickerMapper,
   propertiesMapper: muiPropertiesMapper,
   builderMapper: muiPBuilderMapper,
-  BuilderTemplate: muiBuilderTemplate
+  BuilderTemplate: muiBuilderTemplate,
+  componentMapper: muiComponentMapper
 };
 
 const Demo = () => {
@@ -282,8 +287,9 @@ const Demo = () => {
           schemaTemplate={schemaTemplate}
           pickerMapper={state.pickerMapper}
           componentProperties={componentProperties}
-          componentMapper={state.builderMapper}
+          builderMapper={state.builderMapper}
           propertiesMapper={state.propertiesMapper}
+          componentMapper={state.componentMapper}
           cloneWhileDragging
           disableDrag={false}
           disableAdd={false}

--- a/mui-mappers/builder-mapper.js
+++ b/mui-mappers/builder-mapper.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { componentTypes } from '@data-driven-forms/react-form-renderer';
-import { componentMapper } from '@data-driven-forms/mui-component-mapper';
 
 import clsx from 'clsx';
 
@@ -35,6 +34,7 @@ const snapshotPropType = PropTypes.shape({ isDragging: PropTypes.bool }).isRequi
 const childrenPropType = PropTypes.oneOfType([PropTypes.node, PropTypes.arrayOf(PropTypes.node)]);
 
 const commonPropTypes = {
+  Component: PropTypes.func,
   component: PropTypes.string,
   innerProps: PropTypes.shape({
     snapshot: snapshotPropType
@@ -205,40 +205,31 @@ ComponentWrapper.propTypes = {
   hideField: PropTypes.bool
 };
 
-const TextField = ({ innerProps: { snapshot, hideField }, propertyName, fieldId, propertyValidation, hasPropertyError, ...props }) => {
-  const Component = componentMapper[componentTypes.TEXT_FIELD];
-  return (
-    <ComponentWrapper hideField={hideField}>
-      <Component {...props} label={snapshot.isDragging ? props.label || 'Text input' : props.label} />
-    </ComponentWrapper>
-  );
-};
+const TextField = ({ Component, innerProps: { snapshot, hideField }, propertyName, fieldId, propertyValidation, hasPropertyError, ...props }) => (
+  <ComponentWrapper hideField={hideField}>
+    <Component {...props} label={snapshot.isDragging ? props.label || 'Text input' : props.label} />
+  </ComponentWrapper>
+);
 
 TextField.propTypes = {
   ...commonPropTypes
 };
 
-const CheckBoxField = ({ innerProps: { hideField }, id, propertyValidation, ...props }) => {
-  const Component = componentMapper[componentTypes.CHECKBOX];
-  return (
-    <ComponentWrapper hideField={hideField}>
-      <Component {...props} label={props.label || 'Please provide label'} />
-    </ComponentWrapper>
-  );
-};
+const CheckBoxField = ({ Component, innerProps: { hideField }, id, propertyValidation, ...props }) => (
+  <ComponentWrapper hideField={hideField}>
+    <Component {...props} label={props.label || 'Please provide label'} />
+  </ComponentWrapper>
+);
 
 CheckBoxField.propTypes = {
   ...commonPropTypes
 };
 
-const SelectField = ({ innerProps: { hideField }, options = [], propertyValidation, ...props }) => {
-  const Component = componentMapper[componentTypes.SELECT];
-  return (
-    <ComponentWrapper hideField={hideField}>
-      <Component {...props} options={options && options.filter(({ deleted }) => !deleted)} />
-    </ComponentWrapper>
-  );
-};
+const SelectField = ({ Component, innerProps: { hideField }, options = [], propertyValidation, ...props }) => (
+  <ComponentWrapper hideField={hideField}>
+    <Component {...props} options={options && options.filter(({ deleted }) => !deleted)} />
+  </ComponentWrapper>
+);
 
 SelectField.propTypes = {
   ...commonPropTypes,
@@ -284,40 +275,31 @@ BuilderColumn.propTypes = {
   isDraggingOver: PropTypes.bool
 };
 
-const DatePickerField = ({ innerProps: { hideField }, propertyValidation, ...props }) => {
-  const Component = componentMapper[componentTypes.DATE_PICKER];
-  return (
-    <ComponentWrapper hideField={hideField}>
-      <Component {...props} />
-    </ComponentWrapper>
-  );
-};
+const DatePickerField = ({ Component, innerProps: { hideField }, propertyValidation, ...props }) => (
+  <ComponentWrapper hideField={hideField}>
+    <Component {...props} />
+  </ComponentWrapper>
+);
 
 DatePickerField.propTypes = {
   ...commonPropTypes
 };
 
-const PlainTextField = ({ innerProps: { hideField }, label, propertyValidation, ...props }) => {
-  const Component = componentMapper[componentTypes.PLAIN_TEXT];
-  return (
-    <ComponentWrapper hideField={hideField}>
-      <Component {...props} label={label || 'Please provide a label to plain text component'} />
-    </ComponentWrapper>
-  );
-};
+const PlainTextField = ({ Component, innerProps: { hideField }, label, propertyValidation, ...props }) => (
+  <ComponentWrapper hideField={hideField}>
+    <Component {...props} label={label || 'Please provide a label to plain text component'} />
+  </ComponentWrapper>
+);
 
 PlainTextField.propTypes = {
   ...commonPropTypes
 };
 
-const RadioField = ({ innerProps: { hideField }, propertyValidation, innerProps, ...props }) => {
-  const Component = componentMapper[componentTypes.RADIO];
-  return (
-    <ComponentWrapper hideField={hideField}>
-      <Component {...props} />
-    </ComponentWrapper>
-  );
-};
+const RadioField = ({ Component, innerProps: { hideField }, propertyValidation, innerProps, ...props }) => (
+  <ComponentWrapper hideField={hideField}>
+    <Component {...props} />
+  </ComponentWrapper>
+);
 
 RadioField.propTypes = {
   ...commonPropTypes,
@@ -329,53 +311,42 @@ RadioField.defaultProps = {
   label: 'Please pick label and options'
 };
 
-const SwitchField = ({ innerProps: { hideField }, propertyValidation, component, ...props }) => {
-  const Component = componentMapper[componentTypes.SWITCH];
-  return (
-    <ComponentWrapper hideField={hideField}>
-      <Component {...props} label={props.label} />
-    </ComponentWrapper>
-  );
-};
+const SwitchField = ({ Component, innerProps: { hideField }, propertyValidation, component, ...props }) => (
+  <ComponentWrapper hideField={hideField}>
+    <Component {...props} label={props.label} />
+  </ComponentWrapper>
+);
 
 SwitchField.propTypes = {
   ...commonPropTypes
 };
 
-const TextAreaField = ({ innerProps: { snapshot, hideField }, propertyValidation, hasPropertyError, ...props }) => {
-  const Component = componentMapper[componentTypes.TEXTAREA];
-  return (
-    <ComponentWrapper hideField={hideField}>
-      <Component {...props} label={snapshot.isDragging ? 'Texarea' : props.label} />
-    </ComponentWrapper>
-  );
-};
+const TextAreaField = ({ Component, innerProps: { snapshot, hideField }, propertyValidation, hasPropertyError, ...props }) => (
+  <ComponentWrapper hideField={hideField}>
+    <Component {...props} label={snapshot.isDragging ? 'Texarea' : props.label} />
+  </ComponentWrapper>
+);
 
 TextAreaField.propTypes = {
   ...commonPropTypes
 };
 
-const SubFormField = ({ title, description, innerProps: { hideField } }) => {
-  const Component = componentMapper[componentTypes.SUB_FORM];
-  return (
-    <ComponentWrapper hideField={hideField}>
-      <Component fields={[]} title={title || 'Subform'} description={description} />
-    </ComponentWrapper>
-  );
-};
+const SubFormField = ({ Component, title, description, innerProps: { hideField } }) => (
+  <ComponentWrapper hideField={hideField}>
+    <Component fields={[]} title={title || 'Subform'} description={description} />
+  </ComponentWrapper>
+);
 
 SubFormField.propTypes = {
+  ...commonPropTypes,
   innerProps: PropTypes.shape({ hideField: PropTypes.bool }).isRequired
 };
 
-const DualListSelectField = ({ innerProps: { hideField }, ...props }) => {
-  const Component = componentMapper[componentTypes.DUAL_LIST_SELECT];
-  return (
-    <ComponentWrapper hideField={hideField}>
-      <Component {...props} />
-    </ComponentWrapper>
-  );
-};
+const DualListSelectField = ({ Component, innerProps: { hideField }, ...props }) => (
+  <ComponentWrapper hideField={hideField}>
+    <Component {...props} />
+  </ComponentWrapper>
+);
 
 DualListSelectField.propTypes = {
   ...commonPropTypes,
@@ -387,14 +358,11 @@ DualListSelectField.defaultProps = {
   label: 'Please pick label and options'
 };
 
-const SliderField = ({ innerProps: { hideField }, ...props }) => {
-  const Component = componentMapper[componentTypes.SLIDER];
-  return (
-    <ComponentWrapper hideField={hideField}>
-      <Component {...props} />
-    </ComponentWrapper>
-  );
-};
+const SliderField = ({ Component, innerProps: { hideField }, ...props }) => (
+  <ComponentWrapper hideField={hideField}>
+    <Component {...props} />
+  </ComponentWrapper>
+);
 
 SliderField.propTypes = {
   ...commonPropTypes

--- a/mui-mappers/builder-mapper.js
+++ b/mui-mappers/builder-mapper.js
@@ -34,7 +34,7 @@ const snapshotPropType = PropTypes.shape({ isDragging: PropTypes.bool }).isRequi
 const childrenPropType = PropTypes.oneOfType([PropTypes.node, PropTypes.arrayOf(PropTypes.node)]);
 
 const commonPropTypes = {
-  Component: PropTypes.func,
+  Component: PropTypes.elementType,
   component: PropTypes.string,
   innerProps: PropTypes.shape({
     snapshot: snapshotPropType

--- a/pf4-mappers/builder-mapper.js
+++ b/pf4-mappers/builder-mapper.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { componentTypes } from '@data-driven-forms/react-form-renderer';
-import { componentMapper } from '@data-driven-forms/pf4-component-mapper';
 
 import { Button, Card, CardBody, CardHeader, Form, FormGroup, Title, Tab, Tabs } from '@patternfly/react-core';
 import { TrashIcon, TimesIcon, GripVerticalIcon, EyeSlashIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
@@ -12,6 +11,7 @@ const snapshotPropType = PropTypes.shape({ isDragging: PropTypes.bool }).isRequi
 const childrenPropType = PropTypes.oneOfType([PropTypes.node, PropTypes.arrayOf(PropTypes.node)]);
 
 const commonPropTypes = {
+  Component: PropTypes.func,
   component: PropTypes.string,
   innerProps: PropTypes.shape({
     snapshot: snapshotPropType
@@ -40,40 +40,31 @@ ComponentWrapper.propTypes = {
   hideField: PropTypes.bool
 };
 
-const TextField = ({ innerProps: { snapshot, hideField }, propertyName, fieldId, propertyValidation, hasPropertyError, ...props }) => {
-  const Component = componentMapper[componentTypes.TEXT_FIELD];
-  return (
-    <ComponentWrapper hideField={hideField}>
-      <Component {...props} label={snapshot.isDragging ? props.label || 'Text input' : props.label} />
-    </ComponentWrapper>
-  );
-};
+const TextField = ({ innerProps: { snapshot, hideField }, Component, propertyName, fieldId, propertyValidation, hasPropertyError, ...props }) => (
+  <ComponentWrapper hideField={hideField}>
+    <Component {...props} label={snapshot.isDragging ? props.label || 'Text input' : props.label} />
+  </ComponentWrapper>
+);
 
 TextField.propTypes = {
   ...commonPropTypes
 };
 
-const CheckBoxField = ({ innerProps: { hideField }, id, propertyValidation, ...props }) => {
-  const Component = componentMapper[componentTypes.CHECKBOX];
-  return (
-    <ComponentWrapper hideField={hideField}>
-      <Component {...props} label={props.label || 'Please provide label'} />
-    </ComponentWrapper>
-  );
-};
+const CheckBoxField = ({ innerProps: { hideField }, Component, id, propertyValidation, ...props }) => (
+  <ComponentWrapper hideField={hideField}>
+    <Component {...props} label={props.label || 'Please provide label'} />
+  </ComponentWrapper>
+);
 
 CheckBoxField.propTypes = {
   ...commonPropTypes
 };
 
-const SelectField = ({ innerProps: { hideField }, options, propertyValidation, ...props }) => {
-  const Component = componentMapper[componentTypes.SELECT];
-  return (
-    <ComponentWrapper hideField={hideField}>
-      <Component {...props} options={options && options.filter(({ deleted }) => !deleted)} />
-    </ComponentWrapper>
-  );
-};
+const SelectField = ({ innerProps: { hideField }, Component, options, propertyValidation, ...props }) => (
+  <ComponentWrapper hideField={hideField}>
+    <Component {...props} options={options && options.filter(({ deleted }) => !deleted)} />
+  </ComponentWrapper>
+);
 
 SelectField.propTypes = {
   ...commonPropTypes,
@@ -103,53 +94,42 @@ FieldLayout.propTypes = {
   selected: PropTypes.bool
 };
 
-const BuilderColumn = ({ children, isDraggingOver, ...props }) => {
-  return (
-    <Card {...props} className={'pf4-builder-column'}>
-      <CardBody className="pf-c-form">{children}</CardBody>
-    </Card>
-  );
-};
+const BuilderColumn = ({ children, isDraggingOver, ...props }) => (
+  <Card {...props} className={'pf4-builder-column'}>
+    <CardBody className="pf-c-form">{children}</CardBody>
+  </Card>
+);
 
 BuilderColumn.propTypes = {
   className: PropTypes.string,
   children: childrenPropType
 };
 
-const DatePickerField = ({ innerProps: { hideField }, propertyValidation, ...props }) => {
-  const Component = componentMapper[componentTypes.DATE_PICKER];
-  return (
-    <ComponentWrapper hideField={hideField}>
-      <Component {...props} />
-    </ComponentWrapper>
-  );
-};
+const DatePickerField = ({ innerProps: { hideField }, Component, propertyValidation, ...props }) => (
+  <ComponentWrapper hideField={hideField}>
+    <Component {...props} />
+  </ComponentWrapper>
+);
 
 DatePickerField.propTypes = {
   ...commonPropTypes
 };
 
-const PlainTextField = ({ innerProps: { hideField }, label, propertyValidation, ...props }) => {
-  const Component = componentMapper[componentTypes.PLAIN_TEXT];
-  return (
-    <ComponentWrapper hideField={hideField}>
-      <Component {...props} label={label || 'Please provide a label to plain text component'} />
-    </ComponentWrapper>
-  );
-};
+const PlainTextField = ({ innerProps: { hideField }, Component, label, propertyValidation, ...props }) => (
+  <ComponentWrapper hideField={hideField}>
+    <Component {...props} label={label || 'Please provide a label to plain text component'} />
+  </ComponentWrapper>
+);
 
 PlainTextField.propTypes = {
   ...commonPropTypes
 };
 
-const RadioField = ({ innerProps: { hideField }, propertyValidation, innerProps, ...props }) => {
-  const Component = componentMapper[componentTypes.RADIO];
-  return (
-    <ComponentWrapper hideField={hideField}>
-      <Component {...props} />
-    </ComponentWrapper>
-  );
-};
+const RadioField = ({ innerProps: { hideField }, Component, propertyValidation, innerProps, ...props }) => (
+  <ComponentWrapper hideField={hideField}>
+    <Component {...props} />
+  </ComponentWrapper>
+);
 
 RadioField.propTypes = {
   ...commonPropTypes,
@@ -161,53 +141,42 @@ RadioField.defaultProps = {
   label: 'Please pick label and options'
 };
 
-const SwitchField = ({ innerProps: { snapshot, hideField }, propertyValidation, ...props }) => {
-  const Component = componentMapper[componentTypes.SWITCH];
-  return (
-    <ComponentWrapper hideField={hideField}>
-      <Component {...props} label={snapshot.isDragging ? 'Switch field' : props.label} />
-    </ComponentWrapper>
-  );
-};
+const SwitchField = ({ innerProps: { snapshot, hideField }, Component, propertyValidation, ...props }) => (
+  <ComponentWrapper hideField={hideField}>
+    <Component {...props} label={snapshot.isDragging ? 'Switch field' : props.label} />
+  </ComponentWrapper>
+);
 
 SwitchField.propTypes = {
   ...commonPropTypes
 };
 
-const TextAreaField = ({ innerProps: { snapshot, hideField }, propertyValidation, hasPropertyError, ...props }) => {
-  const Component = componentMapper[componentTypes.TEXTAREA];
-  return (
-    <ComponentWrapper hideField={hideField}>
-      <Component {...props} label={snapshot.isDragging ? 'Texarea' : props.label} />
-    </ComponentWrapper>
-  );
-};
+const TextAreaField = ({ innerProps: { snapshot, hideField }, Component, propertyValidation, hasPropertyError, ...props }) => (
+  <ComponentWrapper hideField={hideField}>
+    <Component {...props} label={snapshot.isDragging ? 'Texarea' : props.label} />
+  </ComponentWrapper>
+);
 
 TextAreaField.propTypes = {
   ...commonPropTypes
 };
 
-const SubFormField = ({ title, description, innerProps: { hideField } }) => {
-  const Component = componentMapper[componentTypes.SUB_FORM];
-  return (
-    <ComponentWrapper hideField={hideField}>
-      <Component fields={[]} title={title || 'Subform'} description={description} />
-    </ComponentWrapper>
-  );
-};
+const SubFormField = ({ title, description, Component, innerProps: { hideField } }) => (
+  <ComponentWrapper hideField={hideField}>
+    <Component fields={[]} title={title || 'Subform'} description={description} />
+  </ComponentWrapper>
+);
 
 SubFormField.propTypes = {
+  ...commonPropTypes,
   innerProps: PropTypes.shape({ hideField: PropTypes.bool }).isRequired
 };
 
-const DualListSelectField = ({ innerProps: { hideField }, propertyValidation, innerProps, ...props }) => {
-  const Component = componentMapper[componentTypes.DUAL_LIST_SELECT];
-  return (
-    <ComponentWrapper hideField={hideField}>
-      <Component {...props} />
-    </ComponentWrapper>
-  );
-};
+const DualListSelectField = ({ innerProps: { hideField }, Component, propertyValidation, innerProps, ...props }) => (
+  <ComponentWrapper hideField={hideField}>
+    <Component {...props} />
+  </ComponentWrapper>
+);
 
 DualListSelectField.propTypes = {
   ...commonPropTypes,
@@ -219,14 +188,11 @@ DualListSelectField.defaultProps = {
   label: 'Please pick label and options'
 };
 
-const SliderField = ({ innerProps: { hideField }, ...props }) => {
-  const Component = componentMapper[componentTypes.SLIDER];
-  return (
-    <ComponentWrapper hideField={hideField}>
-      <Component {...props} />
-    </ComponentWrapper>
-  );
-};
+const SliderField = ({ innerProps: { hideField }, Component, ...props }) => (
+  <ComponentWrapper hideField={hideField}>
+    <Component {...props} />
+  </ComponentWrapper>
+);
 
 SliderField.propTypes = {
   ...commonPropTypes

--- a/pf4-mappers/builder-mapper.js
+++ b/pf4-mappers/builder-mapper.js
@@ -11,7 +11,7 @@ const snapshotPropType = PropTypes.shape({ isDragging: PropTypes.bool }).isRequi
 const childrenPropType = PropTypes.oneOfType([PropTypes.node, PropTypes.arrayOf(PropTypes.node)]);
 
 const commonPropTypes = {
-  Component: PropTypes.func,
+  Component: PropTypes.elementType,
   component: PropTypes.string,
   innerProps: PropTypes.shape({
     snapshot: snapshotPropType

--- a/src/component-picker.js
+++ b/src/component-picker.js
@@ -8,7 +8,7 @@ import { ComponentPickerContext } from './layout-context';
 
 const ComponentPicker = () => {
   const {
-    componentMapper: { BuilderColumn }
+    builderMapper: { BuilderColumn }
   } = useContext(ComponentsContext);
   const { fields, disableAdd } = useContext(ComponentPickerContext);
   const dropTargetId = useSelector(({ dropTargets }) => dropTargets[COMPONENTS_LIST].id);

--- a/src/drop-target.js
+++ b/src/drop-target.js
@@ -9,7 +9,7 @@ import { DropTargetContext } from './layout-context';
 
 const DropTarget = () => {
   const {
-    componentMapper: { FormContainer, EmptyTarget }
+    builderMapper: { FormContainer, EmptyTarget }
   } = useContext(ComponentsContext);
   const { disableDrag } = useContext(DropTargetContext);
   const dropTargets = useSelector(({ dropTargets }) => dropTargets);

--- a/src/field.js
+++ b/src/field.js
@@ -7,7 +7,8 @@ import isEqual from 'lodash/isEqual';
 
 const Field = memo(({ fieldId, index, shouldClone, disableDrag, draggingContainer }) => {
   const {
-    componentMapper: { FieldActions, FieldLayout, DragHandle, ...rest }
+    builderMapper: { FieldActions, FieldLayout, DragHandle, ...rest },
+    componentMapper
   } = useContext(ComponentsContext);
   const { clone, isContainer, validate, ...field } = useSelector(({ fields }) => fields[fieldId]);
   const selectedComponent = useSelector(({ selectedComponent }) => selectedComponent);
@@ -78,7 +79,7 @@ const Field = memo(({ fieldId, index, shouldClone, disableDrag, draggingContaine
                 <div>{field.content}</div>
               ) : (
                 <Fragment>
-                  <FieldComponent {...cleanField} innerProps={innerProps} />
+                  <FieldComponent {...cleanField} innerProps={innerProps} Component={componentMapper[field.component]} />
                   {!shouldClone && (
                     <DragHandle disableDrag={disableDrag} hasPropertyError={!!hasPropertyError} dragHandleProps={{ ...provided.dragHandleProps }} />
                   )}

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ ContainerEnd.propTypes = {
 };
 
 const FormBuilder = ({
-  componentMapper,
+  builderMapper,
   componentProperties,
   pickerMapper,
   propertiesMapper,
@@ -24,6 +24,7 @@ const FormBuilder = ({
   mode,
   debug,
   children,
+  componentMapper,
   ...props
 }) => {
   const initialFields = Object.keys(componentProperties).reduce(
@@ -42,11 +43,12 @@ const FormBuilder = ({
   return (
     <ComponentsContext.Provider
       value={{
-        componentMapper: { ...componentMapper, 'container-end': ContainerEnd },
+        builderMapper: { ...builderMapper, 'container-end': ContainerEnd },
         componentProperties,
         pickerMapper,
         propertiesMapper,
-        debug
+        debug,
+        componentMapper
       }}
     >
       <Form onSubmit={() => {}}>
@@ -67,7 +69,7 @@ const FormBuilder = ({
 FormBuilder.propTypes = {
   mode: PropTypes.oneOf(['default', 'subset']),
   debug: PropTypes.bool,
-  componentMapper: PropTypes.object,
+  builderMapper: PropTypes.object,
   componentProperties: PropTypes.shape({
     attributes: PropTypes.arrayOf(
       PropTypes.shape({
@@ -81,7 +83,8 @@ FormBuilder.propTypes = {
   propertiesMapper: PropTypes.object,
   cloneWhileDragging: PropTypes.bool,
   schema: PropTypes.object,
-  schemaTemplate: PropTypes.object
+  schemaTemplate: PropTypes.object,
+  componentMapper: PropTypes.object
 };
 
 FormBuilder.defaultProps = {

--- a/src/picker-field.js
+++ b/src/picker-field.js
@@ -5,16 +5,23 @@ import ComponentsContext from './components-context';
 
 const PickerField = memo(
   ({ field, index }) => {
-    const { pickerMapper, componentMapper } = useContext(ComponentsContext);
+    const { pickerMapper, builderMapper, componentMapper } = useContext(ComponentsContext);
     const Component = pickerMapper[field.component];
-    const Clone = componentMapper[field.component];
+    const Clone = builderMapper[field.component];
     return (
       <Draggable draggableId={field.id} index={index}>
         {(provided, snapshot) => (
           <Fragment>
             <div ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps}>
               {snapshot.isDragging && field.clone ? (
-                <Clone input={{ name: 'template-clone' }} meta={{}} name="template-clone" innerProps={{ snapshot, isClone: true }} />
+                <Clone
+                  input={{ name: 'template-clone' }}
+                  meta={{}}
+                  name="template-clone"
+                  innerProps={{ snapshot, isClone: true }}
+                  component={field.component}
+                  Component={componentMapper[field.component]}
+                />
               ) : (
                 <Component innerProps={{ snapshot, isClone: true }} />
               )}

--- a/src/properties-editor/index.js
+++ b/src/properties-editor/index.js
@@ -21,7 +21,7 @@ const PropertiesEditor = () => {
   const selectedComponent = useSelector(({ selectedComponent }) => selectedComponent, shallowEqual);
   const field = useSelector(({ selectedComponent, fields }) => fields[selectedComponent], shallowEqual);
   const {
-    componentMapper: { PropertiesEditor, PropertyGroup },
+    builderMapper: { PropertiesEditor, PropertyGroup },
     componentProperties,
     propertiesMapper,
     debug

--- a/src/tests/picker-field.test.js
+++ b/src/tests/picker-field.test.js
@@ -26,7 +26,7 @@ describe('PickerField', () => {
     const wrapper = mount(
       <ComponentsContext.Provider
         value={{
-          componentMapper: { pokus: pokusComponent },
+          builderMapper: { pokus: pokusComponent },
           componentProperties: {},
           pickerMapper: { pokus: pokusPicker },
           propertiesMapper: {}

--- a/src/tests/properties-editor/properties-editor.test.js
+++ b/src/tests/properties-editor/properties-editor.test.js
@@ -61,7 +61,7 @@ const ComponentWrapper = ({ store, ...props }) => (
             ]
           }
         },
-        componentMapper: {
+        builderMapper: {
           PropertiesEditor: PropertiesEditorWrapper,
           PropertyGroup
         },


### PR DESCRIPTION
This removes importing DDF components in builderMappers - componentMapper is passed as a prop.

The next step is going to be unify builderMapper/pickerMapper (with possible customization) as all these components are the same.