### PR TITLE
Shared component for picker/builder fields

### DIFF
--- a/mui-mappers/builder-mapper.js
+++ b/mui-mappers/builder-mapper.js
@@ -29,21 +29,10 @@ import VisibilityOffIcon from '@material-ui/icons/VisibilityOff';
 import ArrowBackIcon from '@material-ui/icons/ArrowBack';
 import DeleteIcon from '@material-ui/icons/Delete';
 import CloseIcon from '@material-ui/icons/Close';
+import { builderComponentTypes } from '../src/constants';
 
 const snapshotPropType = PropTypes.shape({ isDragging: PropTypes.bool }).isRequired;
 const childrenPropType = PropTypes.oneOfType([PropTypes.node, PropTypes.arrayOf(PropTypes.node)]);
-
-const commonPropTypes = {
-  Component: PropTypes.elementType,
-  component: PropTypes.string,
-  innerProps: PropTypes.shape({
-    snapshot: snapshotPropType
-  }).isRequired,
-  label: PropTypes.string,
-  preview: PropTypes.bool,
-  id: PropTypes.string,
-  initialized: PropTypes.bool
-};
 
 const useStyles = makeStyles((theme) => ({
   form: {
@@ -181,7 +170,30 @@ const useStyles = makeStyles((theme) => ({
   }
 }));
 
-const ComponentWrapper = ({ hideField, children }) => {
+const prepareLabel = (component, isDragging) =>
+  ({
+    [componentTypes.CHECKBOX]: 'Please, provide label',
+    [componentTypes.PLAIN_TEXT]: 'Please provide a label to plain text component',
+    [componentTypes.DUAL_LIST_SELECT]: 'Please pick label and options',
+    [componentTypes.RADIO]: 'Please pick label and options'
+  }[component] || (isDragging ? component : ''));
+
+const prepareOptions = (component, options = []) =>
+  ({
+    [componentTypes.SELECT]: { options: options.filter(({ deleted }) => !deleted) },
+    [componentTypes.DUAL_LIST_SELECT]: { options },
+    [componentTypes.RADIO]: { options }
+  }[component] || {});
+
+const ComponentWrapper = ({
+  innerProps: { hideField, snapshot },
+  Component,
+  propertyName,
+  fieldId,
+  propertyValidation,
+  hasPropertyError,
+  ...props
+}) => {
   const classes = useStyles();
 
   return (
@@ -195,45 +207,31 @@ const ComponentWrapper = ({ hideField, children }) => {
           [classes.showHiddenIndicator]: hideField
         })}
       />
-      {children}
+      <Component
+        {...props}
+        label={props.label || prepareLabel(props.component, snapshot.isDragging)}
+        {...prepareOptions(props.component, props.options)}
+      />
     </div>
   );
 };
 
 ComponentWrapper.propTypes = {
-  children: childrenPropType,
-  hideField: PropTypes.bool
-};
-
-const TextField = ({ Component, innerProps: { snapshot, hideField }, propertyName, fieldId, propertyValidation, hasPropertyError, ...props }) => (
-  <ComponentWrapper hideField={hideField}>
-    <Component {...props} label={snapshot.isDragging ? props.label || 'Text input' : props.label} />
-  </ComponentWrapper>
-);
-
-TextField.propTypes = {
-  ...commonPropTypes
-};
-
-const CheckBoxField = ({ Component, innerProps: { hideField }, id, propertyValidation, ...props }) => (
-  <ComponentWrapper hideField={hideField}>
-    <Component {...props} label={props.label || 'Please provide label'} />
-  </ComponentWrapper>
-);
-
-CheckBoxField.propTypes = {
-  ...commonPropTypes
-};
-
-const SelectField = ({ Component, innerProps: { hideField }, options = [], propertyValidation, ...props }) => (
-  <ComponentWrapper hideField={hideField}>
-    <Component {...props} options={options && options.filter(({ deleted }) => !deleted)} />
-  </ComponentWrapper>
-);
-
-SelectField.propTypes = {
-  ...commonPropTypes,
-  options: PropTypes.arrayOf(PropTypes.shape({ value: PropTypes.any, label: PropTypes.string }))
+  Component: PropTypes.elementType,
+  component: PropTypes.string,
+  innerProps: PropTypes.shape({
+    snapshot: snapshotPropType,
+    hideField: PropTypes.bool
+  }).isRequired,
+  label: PropTypes.string,
+  preview: PropTypes.bool,
+  id: PropTypes.string,
+  initialized: PropTypes.bool,
+  options: PropTypes.arrayOf(PropTypes.shape({ value: PropTypes.any, label: PropTypes.string })),
+  propertyName: PropTypes.string,
+  fieldId: PropTypes.string,
+  propertyValidation: PropTypes.any,
+  hasPropertyError: PropTypes.bool
 };
 
 const FieldLayout = ({ children, disableDrag, dragging, selected }) => {
@@ -273,99 +271,6 @@ BuilderColumn.propTypes = {
   className: PropTypes.string,
   children: childrenPropType,
   isDraggingOver: PropTypes.bool
-};
-
-const DatePickerField = ({ Component, innerProps: { hideField }, propertyValidation, ...props }) => (
-  <ComponentWrapper hideField={hideField}>
-    <Component {...props} />
-  </ComponentWrapper>
-);
-
-DatePickerField.propTypes = {
-  ...commonPropTypes
-};
-
-const PlainTextField = ({ Component, innerProps: { hideField }, label, propertyValidation, ...props }) => (
-  <ComponentWrapper hideField={hideField}>
-    <Component {...props} label={label || 'Please provide a label to plain text component'} />
-  </ComponentWrapper>
-);
-
-PlainTextField.propTypes = {
-  ...commonPropTypes
-};
-
-const RadioField = ({ Component, innerProps: { hideField }, propertyValidation, innerProps, ...props }) => (
-  <ComponentWrapper hideField={hideField}>
-    <Component {...props} />
-  </ComponentWrapper>
-);
-
-RadioField.propTypes = {
-  ...commonPropTypes,
-  options: PropTypes.arrayOf(PropTypes.shape({ label: PropTypes.string, value: PropTypes.any }))
-};
-
-RadioField.defaultProps = {
-  options: [],
-  label: 'Please pick label and options'
-};
-
-const SwitchField = ({ Component, innerProps: { hideField }, propertyValidation, component, ...props }) => (
-  <ComponentWrapper hideField={hideField}>
-    <Component {...props} label={props.label} />
-  </ComponentWrapper>
-);
-
-SwitchField.propTypes = {
-  ...commonPropTypes
-};
-
-const TextAreaField = ({ Component, innerProps: { snapshot, hideField }, propertyValidation, hasPropertyError, ...props }) => (
-  <ComponentWrapper hideField={hideField}>
-    <Component {...props} label={snapshot.isDragging ? 'Texarea' : props.label} />
-  </ComponentWrapper>
-);
-
-TextAreaField.propTypes = {
-  ...commonPropTypes
-};
-
-const SubFormField = ({ Component, title, description, innerProps: { hideField } }) => (
-  <ComponentWrapper hideField={hideField}>
-    <Component fields={[]} title={title || 'Subform'} description={description} />
-  </ComponentWrapper>
-);
-
-SubFormField.propTypes = {
-  ...commonPropTypes,
-  innerProps: PropTypes.shape({ hideField: PropTypes.bool }).isRequired
-};
-
-const DualListSelectField = ({ Component, innerProps: { hideField }, ...props }) => (
-  <ComponentWrapper hideField={hideField}>
-    <Component {...props} />
-  </ComponentWrapper>
-);
-
-DualListSelectField.propTypes = {
-  ...commonPropTypes,
-  options: PropTypes.arrayOf(PropTypes.shape({ label: PropTypes.string, value: PropTypes.any }))
-};
-
-DualListSelectField.defaultProps = {
-  options: [],
-  label: 'Please pick label and options'
-};
-
-const SliderField = ({ Component, innerProps: { hideField }, ...props }) => (
-  <ComponentWrapper hideField={hideField}>
-    <Component {...props} />
-  </ComponentWrapper>
-);
-
-SliderField.propTypes = {
-  ...commonPropTypes
 };
 
 const PropertiesEditor = ({
@@ -451,11 +356,6 @@ PropertiesEditor.propTypes = {
   handleClose: PropTypes.func.isRequired,
   handleDelete: PropTypes.func,
   hasPropertyError: PropTypes.array
-};
-
-SubFormField.propTypes = {
-  title: PropTypes.string,
-  description: PropTypes.string
 };
 
 const PropertyGroup = ({ className, children, title, handleDelete, ...props }) => {
@@ -547,17 +447,7 @@ const builderMapper = {
   FieldLayout,
   PropertiesEditor,
   FormContainer,
-  [componentTypes.TEXT_FIELD]: TextField,
-  [componentTypes.CHECKBOX]: CheckBoxField,
-  [componentTypes.SELECT]: SelectField,
-  [componentTypes.PLAIN_TEXT]: PlainTextField,
-  [componentTypes.DATE_PICKER]: DatePickerField,
-  [componentTypes.RADIO]: RadioField,
-  [componentTypes.SWITCH]: SwitchField,
-  [componentTypes.TEXTAREA]: TextAreaField,
-  [componentTypes.SUB_FORM]: SubFormField,
-  [componentTypes.DUAL_LIST_SELECT]: DualListSelectField,
-  [componentTypes.SLIDER]: SliderField,
+  [builderComponentTypes.BUILDER_FIELD]: ComponentWrapper,
   BuilderColumn,
   PropertyGroup,
   DragHandle,

--- a/mui-mappers/picker-mapper.js
+++ b/mui-mappers/picker-mapper.js
@@ -12,6 +12,7 @@ import ToggleOffIcon from '@material-ui/icons/ToggleOff';
 import LowPriorityIcon from '@material-ui/icons/LowPriority';
 import TuneIcon from '@material-ui/icons/Tune';
 import { makeStyles } from '@material-ui/core/styles';
+import { builderComponentTypes } from '../src/constants';
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -29,14 +30,42 @@ const useStyles = makeStyles(() => ({
   }
 }));
 
-const PickerRoot = ({ label, icon }) => {
+const labels = {
+  [componentTypes.TEXT_FIELD]: 'Text field',
+  [componentTypes.CHECKBOX]: 'Checkbox',
+  [componentTypes.SELECT]: 'Select',
+  [componentTypes.DATE_PICKER]: 'Date picker',
+  [componentTypes.PLAIN_TEXT]: 'Plain text',
+  [componentTypes.RADIO]: 'Radio',
+  [componentTypes.SWITCH]: 'Switch',
+  [componentTypes.TEXTAREA]: 'Textarea',
+  [componentTypes.SUB_FORM]: 'Sub form',
+  [componentTypes.DUAL_LIST_SELECT]: 'Dual list select',
+  [componentTypes.SLIDER]: 'Slider'
+};
+
+const icons = {
+  [componentTypes.TEXT_FIELD]: <TextFieldsIcon />,
+  [componentTypes.CHECKBOX]: <CheckBoxIcon />,
+  [componentTypes.SELECT]: <FormatListBulletedIcon />,
+  [componentTypes.DATE_PICKER]: <TodayIcon />,
+  [componentTypes.DUAL_LIST_SELECT]: <LowPriorityIcon />,
+  [componentTypes.PLAIN_TEXT]: <ChromeReaderModeIcon />,
+  [componentTypes.RADIO]: <RadioButtonCheckedIcon />,
+  [componentTypes.SWITCH]: <ToggleOffIcon />,
+  [componentTypes.TEXTAREA]: <TextFieldsIcon />,
+  [componentTypes.SUB_FORM]: null,
+  [componentTypes.SLIDER]: <TuneIcon />
+};
+
+const PickerRoot = ({ component }) => {
   const classes = useStyles();
 
   return (
     <div className={classes.root}>
       <Button
         variant="contained"
-        startIcon={icon}
+        startIcon={icons[component]}
         tabIndex={-1}
         classes={{
           label: classes.label,
@@ -45,51 +74,18 @@ const PickerRoot = ({ label, icon }) => {
         color="primary"
         fullWidth
       >
-        {label}
+        {labels[component] || component}
       </Button>
     </div>
   );
 };
 
 PickerRoot.propTypes = {
-  label: PropTypes.string.isRequired,
-  icon: PropTypes.node
+  component: PropTypes.string.isRequired
 };
 
-const TextFieldOption = () => <PickerRoot icon={<TextFieldsIcon />} label="Text field" />;
-
-const CheckboxOptions = () => <PickerRoot icon={<CheckBoxIcon />} label="Checkbox" />;
-
-const SelectOptions = () => <PickerRoot icon={<FormatListBulletedIcon />} label="Select" />;
-
-const DatePickerOption = () => <PickerRoot icon={<TodayIcon />} label="Date picker" />;
-
-const DualListOption = () => <PickerRoot icon={<LowPriorityIcon />} label="Dual list select" />;
-
-const PlainTextOption = () => <PickerRoot icon={<ChromeReaderModeIcon />} label="Plain text" />;
-
-const RadioOption = () => <PickerRoot icon={<RadioButtonCheckedIcon />} label="Radio" />;
-
-const SwitchOption = () => <PickerRoot icon={<ToggleOffIcon />} label="Switch" />;
-
-const TextAreaOption = () => <PickerRoot icon={<TextFieldsIcon />} label="Textarea" />;
-
-const SubFormOption = () => <PickerRoot label="Sub form" />;
-
-const SliderOption = () => <PickerRoot icon={<TuneIcon />} label="Slider" />;
-
 const pickerMapper = {
-  [componentTypes.TEXT_FIELD]: TextFieldOption,
-  [componentTypes.CHECKBOX]: CheckboxOptions,
-  [componentTypes.SELECT]: SelectOptions,
-  [componentTypes.DATE_PICKER]: DatePickerOption,
-  [componentTypes.DUAL_LIST_SELECT]: DualListOption,
-  [componentTypes.PLAIN_TEXT]: PlainTextOption,
-  [componentTypes.RADIO]: RadioOption,
-  [componentTypes.SWITCH]: SwitchOption,
-  [componentTypes.TEXTAREA]: TextAreaOption,
-  [componentTypes.SUB_FORM]: SubFormOption,
-  [componentTypes.SLIDER]: SliderOption
+  [builderComponentTypes.PICKER_FIELD]: PickerRoot
 };
 
 export default pickerMapper;

--- a/pf4-mappers/picker-mapper.js
+++ b/pf4-mappers/picker-mapper.js
@@ -4,53 +4,36 @@ import { componentTypes } from '@data-driven-forms/react-form-renderer';
 import { Button } from '@patternfly/react-core';
 
 import './pf4-mapper-style.css';
+import { builderComponentTypes } from '../src/constants';
 
-const PickerRoot = ({ label }) => (
+const labels = {
+  [componentTypes.TEXT_FIELD]: 'Text field',
+  [componentTypes.CHECKBOX]: 'Checkbox',
+  [componentTypes.SELECT]: 'Select',
+  [componentTypes.DATE_PICKER]: 'Date picker',
+  [componentTypes.PLAIN_TEXT]: 'Plain text',
+  [componentTypes.RADIO]: 'Radio',
+  [componentTypes.SWITCH]: 'Switch',
+  [componentTypes.TEXTAREA]: 'Textarea',
+  [componentTypes.SUB_FORM]: 'Sub form',
+  [componentTypes.DUAL_LIST_SELECT]: 'Dual list select',
+  [componentTypes.SLIDER]: 'Slider'
+};
+
+const PickerRoot = ({ component }) => (
   <div className="pf4-picker-root">
     <Button tabIndex={-1} variant="primary" color="primary">
-      {label}
+      {labels[component] || component}
     </Button>
   </div>
 );
 
 PickerRoot.propTypes = {
-  label: PropTypes.string.isRequired
+  component: PropTypes.string.isRequired
 };
 
-const TextFieldOption = () => <PickerRoot label="Text field" />;
-
-const CheckboxOptions = () => <PickerRoot label="Checkbox" />;
-
-const SelectOptions = () => <PickerRoot label="Select" />;
-
-const DatePickerOption = () => <PickerRoot label="Date picker" />;
-
-const PlainTextOption = () => <PickerRoot label="Plain text" />;
-
-const RadioOption = () => <PickerRoot label="Radio" />;
-
-const SwitchOption = () => <PickerRoot label="Switch" />;
-
-const TextAreaOption = () => <PickerRoot label="Textarea" />;
-
-const SubFormOption = () => <PickerRoot label="Sub form" />;
-
-const DualListSelectOption = () => <PickerRoot label="Dual list select" />;
-
-const SliderOption = () => <PickerRoot label="Slider" />;
-
 const pickerMapper = {
-  [componentTypes.TEXT_FIELD]: TextFieldOption,
-  [componentTypes.CHECKBOX]: CheckboxOptions,
-  [componentTypes.SELECT]: SelectOptions,
-  [componentTypes.DATE_PICKER]: DatePickerOption,
-  [componentTypes.PLAIN_TEXT]: PlainTextOption,
-  [componentTypes.RADIO]: RadioOption,
-  [componentTypes.SWITCH]: SwitchOption,
-  [componentTypes.TEXTAREA]: TextAreaOption,
-  [componentTypes.SUB_FORM]: SubFormOption,
-  [componentTypes.DUAL_LIST_SELECT]: DualListSelectOption,
-  [componentTypes.SLIDER]: SliderOption
+  [builderComponentTypes.PICKER_FIELD]: PickerRoot
 };
 
 export default pickerMapper;

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,4 @@
+export const builderComponentTypes = {
+  BUILDER_FIELD: 'builder-field',
+  PICKER_FIELD: 'picker-field'
+};

--- a/src/field.js
+++ b/src/field.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import ComponentsContext from './components-context';
 import { useDispatch, useSelector } from 'react-redux';
 import isEqual from 'lodash/isEqual';
+import { builderComponentTypes } from './constants';
 
 const Field = memo(({ fieldId, index, shouldClone, disableDrag, draggingContainer }) => {
   const {
@@ -13,7 +14,7 @@ const Field = memo(({ fieldId, index, shouldClone, disableDrag, draggingContaine
   const { clone, isContainer, validate, ...field } = useSelector(({ fields }) => fields[fieldId]);
   const selectedComponent = useSelector(({ selectedComponent }) => selectedComponent);
   const dispatch = useDispatch();
-  const FieldComponent = rest[field.component];
+  const FieldComponent = rest[field.component] || rest[builderComponentTypes.BUILDER_FIELD];
 
   const hasPropertyError = field.propertyValidation && Object.entries(field.propertyValidation).find(([, value]) => value);
   if (field.component === 'container-end') {

--- a/src/picker-field.js
+++ b/src/picker-field.js
@@ -2,12 +2,13 @@ import React, { useContext, Fragment, memo } from 'react';
 import { Draggable } from 'react-beautiful-dnd';
 import PropTypes from 'prop-types';
 import ComponentsContext from './components-context';
+import { builderComponentTypes } from './constants';
 
 const PickerField = memo(
   ({ field, index }) => {
     const { pickerMapper, builderMapper, componentMapper } = useContext(ComponentsContext);
-    const Component = pickerMapper[field.component];
-    const Clone = builderMapper[field.component];
+    const Component = pickerMapper[field.component] || pickerMapper[builderComponentTypes.PICKER_FIELD];
+    const Clone = builderMapper[field.component] || builderMapper[builderComponentTypes.BUILDER_FIELD];
     return (
       <Draggable draggableId={field.id} index={index}>
         {(provided, snapshot) => (
@@ -23,10 +24,10 @@ const PickerField = memo(
                   Component={componentMapper[field.component]}
                 />
               ) : (
-                <Component innerProps={{ snapshot, isClone: true }} />
+                <Component innerProps={{ snapshot, isClone: true }} component={field.component} />
               )}
             </div>
-            {snapshot.isDragging && <Component {...snapshot} />}
+            {snapshot.isDragging && <Component {...snapshot} component={field.component} />}
           </Fragment>
         )}
       </Draggable>


### PR DESCRIPTION
Merge after https://github.com/data-driven-forms/form-builder/pull/19

BuilderField and PickerField can now use shared component, so less code to manage and it's easier to add components to editor. To provide the customization, it's still to possible to add a specific component for each componentType, but I think we could get rid of this and let the shared component managed that.