### PR TITLE
Allow to keep editor open

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -293,6 +293,7 @@ const Demo = () => {
           cloneWhileDragging
           disableDrag={false}
           disableAdd={false}
+          openEditor
           mode="subset"
           debug={false}
           render={({ isValid, getSchema, ...props }) => (

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ const FormBuilder = ({
   debug,
   children,
   componentMapper,
+  openEditor,
   ...props
 }) => {
   const initialFields = Object.keys(componentProperties).reduce(
@@ -48,7 +49,8 @@ const FormBuilder = ({
         pickerMapper,
         propertiesMapper,
         debug,
-        componentMapper
+        componentMapper,
+        openEditor
       }}
     >
       <Form onSubmit={() => {}}>
@@ -84,7 +86,8 @@ FormBuilder.propTypes = {
   cloneWhileDragging: PropTypes.bool,
   schema: PropTypes.object,
   schemaTemplate: PropTypes.object,
-  componentMapper: PropTypes.object
+  componentMapper: PropTypes.object,
+  openEditor: PropTypes.bool
 };
 
 FormBuilder.defaultProps = {

--- a/src/properties-editor/index.js
+++ b/src/properties-editor/index.js
@@ -7,6 +7,7 @@ import MemoizedValidator from './memozied-validator';
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import { SET_FIELD_VALIDATOR, SET_FIELD_PROPERTY, SET_SELECTED_COMPONENT, REMOVE_COMPONENT } from '../builder-state/builder-reducer';
 import convertInitialValue from './convert-initial-value';
+import { FORM_LAYOUT } from '../helpers/create-initial-data';
 
 const validatorOptions = Object.keys(validatorTypes)
   .filter((key) => validatorTypes[key] !== validatorTypes.REQUIRED)
@@ -19,12 +20,16 @@ const checkRequiredDisabled = (field) => {
 const PropertiesEditor = () => {
   const dispatch = useDispatch();
   const selectedComponent = useSelector(({ selectedComponent }) => selectedComponent, shallowEqual);
-  const field = useSelector(({ selectedComponent, fields }) => fields[selectedComponent], shallowEqual);
+  const { field, dropTargets } = useSelector(
+    ({ selectedComponent, fields, dropTargets }) => ({ field: fields[selectedComponent], dropTargets }),
+    shallowEqual
+  );
   const {
     builderMapper: { PropertiesEditor, PropertyGroup },
     componentProperties,
     propertiesMapper,
-    debug
+    debug,
+    openEditor
   } = useContext(ComponentsContext);
   const [requiredDisabled, setRequiredDisabled] = useState(true);
   useEffect(() => {
@@ -32,6 +37,12 @@ const PropertiesEditor = () => {
       setRequiredDisabled(() => checkRequiredDisabled(field));
     }
   }, [selectedComponent, field]);
+
+  useEffect(() => {
+    if (!selectedComponent && openEditor && dropTargets[FORM_LAYOUT].fieldsIds[0]) {
+      dispatch({ type: SET_SELECTED_COMPONENT, payload: dropTargets[FORM_LAYOUT].fieldsIds[0] });
+    }
+  }, []);
 
   if (!selectedComponent) {
     return null;


### PR DESCRIPTION
When used `openEditor` prop:
- on initial load the first field will be selected if exists

