### PR TITLE
Create basic dnd tree using dnd-kit

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -12,13 +12,13 @@ import {
   pickerMapper as muiPickerMapper,
   propertiesMapper as muiPropertiesMapper,
   builderMapper as muiPBuilderMapper,
-  BuilderTemplate as muiBuilderTemplate
+  BuilderTemplate as muiBuilderTemplate,
 } from '../src/mui-builder-mappers';
 import {
   pickerMapper as pf4PickerMapper,
   propertiesMapper as pf4PropertiesMapper,
   builderMapper as pf4PBuilderMapper,
-  BuilderTemplate as pf4BuilderTemplate
+  BuilderTemplate as pf4BuilderTemplate,
 } from '../src/pf4-builder-mappers';
 
 import {
@@ -54,33 +54,34 @@ import {
   CHECKBOX_VARIANT,
   STEP,
   MIN,
-  MAX
+  MAX,
 } from './field-properties';
+import DndKit from '../src/dnd-kit';
 
 const componentProperties = {
   [componentTypes.TEXT_FIELD]: {
-    attributes: [LABEL, HELPER_TEXT, PLACEHOLDER, INPUT_TYPE, IS_DISABLED, IS_READ_ONLY, HIDE_FIELD]
+    attributes: [LABEL, HELPER_TEXT, PLACEHOLDER, INPUT_TYPE, IS_DISABLED, IS_READ_ONLY, HIDE_FIELD],
   },
   [componentTypes.CHECKBOX]: {
-    attributes: [LABEL, IS_DISABLED, OPTIONS, HIDE_FIELD]
+    attributes: [LABEL, IS_DISABLED, OPTIONS, HIDE_FIELD],
   },
   [componentTypes.SELECT]: {
-    attributes: [LABEL, OPTIONS, IS_DISABLED, PLACEHOLDER, HELPER_TEXT, HIDE_FIELD]
+    attributes: [LABEL, OPTIONS, IS_DISABLED, PLACEHOLDER, HELPER_TEXT, HIDE_FIELD],
   },
   [componentTypes.DATE_PICKER]: {
-    attributes: [LABEL, TODAY_BUTTON_LABEL, IS_CLEARABLE, CLOSE_ON_DAY_SELECT, SHOW_TODAY_BUTTON, HIDE_FIELD]
+    attributes: [LABEL, TODAY_BUTTON_LABEL, IS_CLEARABLE, CLOSE_ON_DAY_SELECT, SHOW_TODAY_BUTTON, HIDE_FIELD],
   },
   [componentTypes.PLAIN_TEXT]: { attributes: [MULTI_LINE_LABEL] },
   [componentTypes.RADIO]: { attributes: [LABEL, IS_DISABLED, OPTIONS, HIDE_FIELD] },
   [componentTypes.SWITCH]: {
-    attributes: [LABEL, IS_READ_ONLY, IS_DISABLED, HIDE_FIELD]
+    attributes: [LABEL, IS_READ_ONLY, IS_DISABLED, HIDE_FIELD],
   },
   [componentTypes.TEXTAREA]: {
-    attributes: [LABEL, HELPER_TEXT, IS_READ_ONLY, IS_DISABLED, HIDE_FIELD]
+    attributes: [LABEL, HELPER_TEXT, IS_READ_ONLY, IS_DISABLED, HIDE_FIELD],
   },
   [componentTypes.SUB_FORM]: {
     isContainer: true,
-    attributes: [TITLE, DESCRIPTION]
+    attributes: [TITLE, DESCRIPTION],
   },
   [componentTypes.DUAL_LIST_SELECT]: {
     attributes: [
@@ -103,12 +104,12 @@ const componentProperties = {
       FILTER_VALUE_TITLE,
       FILTER_VALUE_TEXT,
       FILTER_OPTIONS_TEXT,
-      CHECKBOX_VARIANT
-    ]
+      CHECKBOX_VARIANT,
+    ],
   },
   [componentTypes.SLIDER]: {
-    attributes: [LABEL, HELPER_TEXT, DESCRIPTION, HIDE_FIELD, MIN, MAX, STEP]
-  }
+    attributes: [LABEL, HELPER_TEXT, DESCRIPTION, HIDE_FIELD, MIN, MAX, STEP],
+  },
 };
 
 const schema = {
@@ -123,17 +124,17 @@ const schema = {
       validate: [
         {
           type: validatorTypes.REQUIRED,
-          message: 'This field is required'
+          message: 'This field is required',
         },
         {
           type: validatorTypes.MIN_LENGTH,
-          threshold: 7
+          threshold: 7,
         },
         {
           type: validatorTypes.MAX_LENGTH,
-          threshold: 10
-        }
-      ]
+          threshold: 10,
+        },
+      ],
     },
     {
       component: componentTypes.TEXT_FIELD,
@@ -144,13 +145,13 @@ const schema = {
       validate: [
         {
           type: validatorTypes.MAX_NUMBER_VALUE,
-          value: 33
+          value: 33,
         },
         {
           type: validatorTypes.MIN_NUMBER_VALUE,
-          value: 14
-        }
-      ]
+          value: 14,
+        },
+      ],
     },
     {
       component: componentTypes.TEXT_FIELD,
@@ -159,9 +160,9 @@ const schema = {
       validate: [
         {
           type: validatorTypes.PATTERN,
-          pattern: /^Foo$/
-        }
-      ]
+          pattern: /^Foo$/,
+        },
+      ],
     },
     {
       component: componentTypes.SELECT,
@@ -171,15 +172,15 @@ const schema = {
       options: [
         {
           label: 'Option 1',
-          value: '1'
+          value: '1',
         },
         {
           label: 'Option 2',
-          value: '2'
-        }
-      ]
-    }
-  ]
+          value: '2',
+        },
+      ],
+    },
+  ],
 };
 
 const schemaTemplate = {
@@ -193,17 +194,17 @@ const schemaTemplate = {
       validate: [
         {
           type: validatorTypes.REQUIRED,
-          message: 'This field is required'
+          message: 'This field is required',
         },
         {
           type: validatorTypes.MIN_LENGTH,
-          threshold: 5
+          threshold: 5,
         },
         {
           type: validatorTypes.MAX_LENGTH,
-          threshold: 10
-        }
-      ]
+          threshold: 10,
+        },
+      ],
     },
     {
       component: componentTypes.TEXT_FIELD,
@@ -215,13 +216,13 @@ const schemaTemplate = {
       validate: [
         {
           type: validatorTypes.MAX_NUMBER_VALUE,
-          value: 50
+          value: 50,
         },
         {
           type: validatorTypes.MIN_NUMBER_VALUE,
-          value: 14
-        }
-      ]
+          value: 14,
+        },
+      ],
     },
     {
       component: componentTypes.TEXT_FIELD,
@@ -230,9 +231,9 @@ const schemaTemplate = {
       validate: [
         {
           type: validatorTypes.PATTERN,
-          pattern: /^Foo$/
-        }
-      ]
+          pattern: /^Foo$/,
+        },
+      ],
     },
     {
       component: componentTypes.SELECT,
@@ -242,19 +243,19 @@ const schemaTemplate = {
       options: [
         {
           label: 'Option 1',
-          value: '1'
+          value: '1',
         },
         {
           label: 'Option 2',
-          value: '2'
+          value: '2',
         },
         {
           label: 'Option 3',
-          value: '3'
-        }
-      ]
-    }
-  ]
+          value: '3',
+        },
+      ],
+    },
+  ],
 };
 
 const pf4State = {
@@ -262,7 +263,7 @@ const pf4State = {
   propertiesMapper: pf4PropertiesMapper,
   builderMapper: pf4PBuilderMapper,
   BuilderTemplate: pf4BuilderTemplate,
-  componentMapper: pf4ComponentMapper
+  componentMapper: pf4ComponentMapper,
 };
 
 const muiState = {
@@ -270,7 +271,7 @@ const muiState = {
   propertiesMapper: muiPropertiesMapper,
   builderMapper: muiPBuilderMapper,
   BuilderTemplate: muiBuilderTemplate,
-  componentMapper: muiComponentMapper
+  componentMapper: muiComponentMapper,
 };
 
 const Demo = () => {
@@ -309,4 +310,6 @@ const Demo = () => {
   );
 };
 
-ReactDom.render(<Demo />, document.getElementById('root'));
+const DndKitDemo = () => <DndKit />;
+
+ReactDom.render(<DndKitDemo />, document.getElementById('root'));

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "@babel/preset-env": "^7.11.5",
     "@babel/preset-react": "^7.10.4",
     "@data-driven-forms/mui-component-mapper": "^3.4.1",
-    "@data-driven-forms/react-form-renderer": "^3.4.1",
     "@data-driven-forms/pf4-component-mapper": "^3.4.1",
+    "@data-driven-forms/react-form-renderer": "^3.4.1",
     "@material-ui/core": "4.11.0",
     "@material-ui/icons": "^4.9.1",
     "@patternfly/react-core": "^4.101.3",
@@ -65,6 +65,8 @@
     "webpack-dev-server": "^3.9.0"
   },
   "dependencies": {
+    "@dnd-kit/core": "^2.1.2",
+    "@dnd-kit/sortable": "^2.0.1",
     "clsx": "^1.1.1",
     "lodash": "^4.17.20",
     "prop-types": "^15.7.2",

--- a/src/dnd-kit/backend.js
+++ b/src/dnd-kit/backend.js
@@ -1,0 +1,142 @@
+import { arrayMove } from '@dnd-kit/sortable';
+
+export const MAIN_CONTAINER = 'main-container';
+
+const SET_ACTIVE_ID = 'SET_ACTIVE_ID';
+const SET_ITEMS = 'SET_ITEMS';
+const ADD_ITEM = 'ADD_ITEM';
+const SORT_ITEMS = 'SORT_ITEMS';
+export const initialState = {
+  activeId: undefined,
+  containers: {
+    [MAIN_CONTAINER]: {
+      accessot: 'tree',
+      children: [],
+    },
+  },
+};
+
+export const setActiveId = (id) => ({
+  type: SET_ACTIVE_ID,
+  payload: id,
+});
+
+export const setItems = (items) => ({
+  type: SET_ITEMS,
+  payload: items,
+});
+
+export const addItem = (itemId, collisionId) => ({
+  type: ADD_ITEM,
+  payload: {
+    itemId,
+    collisionId,
+  },
+});
+
+export const sortItems = (itemId, collisionId) => ({
+  type: SORT_ITEMS,
+  payload: {
+    itemId,
+    collisionId,
+  },
+});
+
+const addToContainer = (state, containerId, newId, collisionId) => {
+  const position = state.containers[containerId].children.findIndex((id) => id === collisionId);
+  return {
+    ...state,
+    containers: {
+      ...state.containers,
+      [containerId]: {
+        ...state.containers[containerId],
+        children: [
+          ...state.containers[containerId].children.slice(0, position + 1),
+          newId,
+          ...state.containers[containerId].children.slice(position + 1),
+        ],
+      },
+    },
+  };
+};
+
+const findInjection = (state, collisionId) => {
+  let firstContainer;
+  if (Object.keys(state.containers).find((key) => key === collisionId)) {
+    firstContainer = collisionId;
+  }
+  if (!firstContainer) {
+    let currentIndex = 0;
+    const allContainers = Object.entries(state.containers);
+    while (!firstContainer || currentIndex < Object.keys(state.containers).length) {
+      const currField =
+        allContainers[currentIndex][1].children.find((value) => {
+          return value === collisionId;
+        }) || [];
+      firstContainer = currField ? allContainers[currentIndex][0] : firstContainer;
+      currentIndex += 1;
+    }
+  }
+  if (!firstContainer) {
+    firstContainer = MAIN_CONTAINER;
+  }
+  return firstContainer;
+};
+
+const addNewItem = (state, { itemId, collisionId }) => {
+  const newId = itemId.replace(/^template/, `field-${Date.now() + Math.random()}`);
+  if (collisionId === MAIN_CONTAINER) {
+    return {
+      ...state,
+      containers: {
+        ...state.containers,
+        [MAIN_CONTAINER]: {
+          ...state.containers[MAIN_CONTAINER],
+          children: [...state.containers[MAIN_CONTAINER].children, newId],
+        },
+      },
+    };
+  }
+  return addToContainer(state, findInjection(state, collisionId), newId, collisionId);
+};
+
+const sortTreeItems = (state, { itemId, collisionId }) => {
+  const currentContainer = findInjection(state, collisionId);
+  const targetContainer = findInjection(state, collisionId);
+  if (currentContainer === targetContainer) {
+    const oldIndex = state.containers[currentContainer].children.indexOf(itemId);
+    const newIndex = state.containers[currentContainer].children.indexOf(collisionId);
+    return {
+      ...state,
+      containers: {
+        ...state.containers,
+        [currentContainer]: {
+          ...state.containers[currentContainer],
+          children: arrayMove(state.containers[currentContainer].children, oldIndex, newIndex),
+        },
+      },
+    };
+  } else {
+    /**
+     * Mooving between different containers
+     * TBD
+     */
+  }
+};
+
+const reducer = (state, action) => {
+  switch (action.type) {
+    case SET_ACTIVE_ID:
+      return { ...state, activeId: action.payload };
+    case SET_ITEMS:
+      return { ...state, tree: action.payload };
+    case SORT_ITEMS:
+      return sortTreeItems(state, action.payload);
+    case ADD_ITEM:
+      return addNewItem(state, action.payload);
+    default:
+      return state;
+  }
+};
+
+export default reducer;

--- a/src/dnd-kit/container.js
+++ b/src/dnd-kit/container.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useDroppable } from '@dnd-kit/core';
+
+const Container = ({ id, style, children }) => {
+  const { isOver, setNodeRef } = useDroppable({
+    id,
+  });
+
+  const innerStylestyle = {
+    color: isOver ? 'green' : undefined,
+    width: '100%',
+    minHeight: 600,
+    ...style,
+  };
+
+  return (
+    <div id={id} ref={setNodeRef} style={innerStylestyle}>
+      {children}
+    </div>
+  );
+};
+
+Container.propTypes = {
+  id: PropTypes.string.isRequired,
+  style: PropTypes.object,
+  children: PropTypes.node.isRequired,
+};
+
+export default Container;

--- a/src/dnd-kit/draggable-source.js
+++ b/src/dnd-kit/draggable-source.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import Draggable from './draggable';
+
+const avaiableItems = [
+  { component: 'text-field', id: 'template-text-field' },
+  { id: 'template-switch', component: 'switch' },
+  { component: 'container', id: 'template-nested-cmp' },
+];
+
+const DraggableSource = () => (
+  <div style={{ width: 200, display: 'flex', flexDirection: 'column' }}>
+    {avaiableItems.map(({ id, component, ...rest }) => (
+      <Draggable id={id} key={id} {...rest}>
+        <button>{component}</button>
+      </Draggable>
+    ))}
+  </div>
+);
+
+export default DraggableSource;

--- a/src/dnd-kit/draggable.js
+++ b/src/dnd-kit/draggable.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useDraggable } from '@dnd-kit/core';
+
+const Draggable = ({ id, style, ...props }) => {
+  const { attributes, listeners, setNodeRef, transform } = useDraggable({
+    id,
+  });
+
+  const innerStyle = transform
+    ? {
+        transform: `translate3d(${transform.x}px, ${transform.y}px, 0)`,
+      }
+    : undefined;
+
+  return (
+    <span ref={setNodeRef} style={{ ...style, ...innerStyle }} {...listeners} {...attributes}>
+      {props.children}
+    </span>
+  );
+};
+Draggable.propTypes = {
+  id: PropTypes.string.isRequired,
+  style: PropTypes.object,
+  children: PropTypes.node.isRequired,
+};
+
+export default Draggable;

--- a/src/dnd-kit/index.js
+++ b/src/dnd-kit/index.js
@@ -1,0 +1,67 @@
+import { closestCorners, DndContext, DragOverlay, KeyboardSensor, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
+import { arrayMove, SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import React, { useReducer, useState } from 'react';
+import backend, { addItem, initialState, MAIN_CONTAINER, setActiveId, setItems, sortItems } from './backend';
+import Container from './container';
+import DraggableSource from './draggable-source';
+import Item from './item';
+import SortableContainer from './sortable-container';
+import SortableItem from './sortable-item';
+
+const DndKit = () => {
+  const [
+    {
+      containers: {
+        [MAIN_CONTAINER]: { children: tree },
+      },
+      activeId,
+    },
+    dispatch,
+  ] = useReducer(backend, initialState);
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  const bindSetActiveId = (id) => dispatch(setActiveId(id));
+  const bindSetItems = (items) => dispatch(setItems(items));
+  const bindSortItems = (...args) => dispatch(sortItems(...args));
+
+  const handleDragStart = (event) => {
+    const { active } = event;
+    bindSetActiveId(active.id);
+  };
+
+  const handleAddItem = (id, over) => dispatch(addItem(id, over));
+
+  const handleDragEnd = (event) => {
+    const { active, over } = event;
+    if (active?.id.match(/^template-/)) {
+      handleAddItem(active.id, over.id);
+    } else if (active.id !== over.id) {
+      bindSortItems(active.id, over.id);
+    }
+
+    bindSetActiveId(null);
+  };
+
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCorners} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+      <div style={{ display: 'flex', flexDirection: 'row' }}>
+        <DraggableSource />
+        <Container style={{ background: 'tomato', padding: 40 }} id={MAIN_CONTAINER}>
+          <SortableContext items={tree} strategy={verticalListSortingStrategy}>
+            {tree.map((id) => (
+              <SortableItem key={id} id={id} />
+            ))}
+          </SortableContext>
+          <DragOverlay>{activeId ? <Item id={activeId}>{activeId}</Item> : null}</DragOverlay>
+        </Container>
+      </div>
+    </DndContext>
+  );
+};
+
+export default DndKit;

--- a/src/dnd-kit/item.js
+++ b/src/dnd-kit/item.js
@@ -1,0 +1,16 @@
+import React, { forwardRef } from 'react';
+import PropTypes from 'prop-types';
+
+const Item = forwardRef(({ children, ...props }, ref) => {
+  return (
+    <div style={{ padding: 16, background: 'blue' }} {...props} ref={ref}>
+      {children}
+    </div>
+  );
+});
+
+Item.propTypes = {
+  children: PropTypes.node,
+};
+
+export default Item;

--- a/src/dnd-kit/sortable-container.js
+++ b/src/dnd-kit/sortable-container.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+
+const SortableContainer = ({ id, isActive, style, children }) => {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id });
+
+  const internalStyle = {
+    padding: 16,
+    background: 'tomato',
+    color: 'white',
+    margin: 8,
+    visibility: isActive ? 'hidden' : undefined,
+    ...style,
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+  return (
+    <div id={id} ref={setNodeRef} style={internalStyle} {...attributes} {...listeners}>
+      {children}
+    </div>
+  );
+};
+
+SortableContainer.propTypes = {
+  id: PropTypes.string.isRequired,
+  isActive: PropTypes.bool,
+  style: PropTypes.object,
+  children: PropTypes.node,
+};
+
+export default SortableContainer;

--- a/src/dnd-kit/sortable-item.js
+++ b/src/dnd-kit/sortable-item.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import Item from './item';
+
+const SortableItem = (props) => {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: props.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <Item ref={setNodeRef} style={style} {...attributes} {...listeners}>
+      {props.id}
+    </Item>
+  );
+};
+
+SortableItem.propTypes = {
+  id: PropTypes.string.isRequired,
+};
+
+export default SortableItem;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1248,6 +1248,38 @@
   dependencies:
     "@date-io/core" "^1.3.13"
 
+"@dnd-kit/accessibility@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/accessibility/-/accessibility-2.0.0.tgz#d1f265ebedde6a66b71bb69fd8bc900b5138a8e2"
+  integrity sha512-L0KOQnqFR0MJ/IwJIS1A0tvgr47LrWzclJy7wW5i8/3rkdixUzkiD78rYnX7TrFnFNtuEgVxiGSsX2oIlulmUg==
+  dependencies:
+    tslib "^2.0.0"
+
+"@dnd-kit/core@^2.1.0", "@dnd-kit/core@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/core/-/core-2.1.2.tgz#08d1fede9dd4c5a0f084cc2b95a434813ee9fda7"
+  integrity sha512-mJFKQUWOWq/yuD3jfPON4DuwWVGN/eS8s7GX9I5GbjG3i7Udt8I6ij1ZFinISSTTZxNVdBBcRKO4ctRecDkNKA==
+  dependencies:
+    "@dnd-kit/accessibility" "^2.0.0"
+    "@dnd-kit/utilities" "^1.0.2"
+    tslib "^2.0.0"
+
+"@dnd-kit/sortable@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/sortable/-/sortable-2.0.1.tgz#27da1a4b8f4e248d794964c5fd8734b000be5791"
+  integrity sha512-HfrIKkIXu+lZge8rRALeELJJA7zhWHubU1bCBAnVgKRhPmPYomN4X6szG81uquSD9Fvq04qBbwyw+uuBp1aJJg==
+  dependencies:
+    "@dnd-kit/core" "^2.1.0"
+    "@dnd-kit/utilities" "^1.0.2"
+    tslib "^2.0.0"
+
+"@dnd-kit/utilities@^1.0.2":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/utilities/-/utilities-1.0.3.tgz#9742d229a095bfd08d120b28657c936fb911237f"
+  integrity sha512-TlbsZ3pSiJ6jTDVuGDLY7yoHAjaiFyBWctxDslxAocUeCQVDlcpkGXcPtUKYyGczruUoYapsKlZS5rhLDR+RUg==
+  dependencies:
+    tslib "^2.0.0"
+
 "@emotion/cache@^10.0.27", "@emotion/cache@^10.0.9":
   version "10.0.29"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.29.tgz#87e7e64f412c060102d589fe7c6dc042e6f9d1e0"
@@ -9635,6 +9667,11 @@ tslib@^1.10.0, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
+  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
 tslib@^2.0.1:
   version "2.0.3"


### PR DESCRIPTION
This creates a single-level dnd tree that has basically the same dnd capabilities as the current implementation. But we have a closes root container detection which will be used when having multiple containers in the future.

On each drop, we detect what is the collision parent container which will allow us to drop items directly into tested structures.

Implementation is not finished, I want to add nested capabilities in follow-up PR.